### PR TITLE
Add valid-mask support for ICU codebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ python main.py \
 --adapt True
 ```
 
+### Train ICU Codebook
+
+```bash
+python icu_codebook.py --data_root PATH_TO_DATA --device cuda:0 \
+    --save_path ./vq.ckpt --epochs 30 --lr 1e-3
+```
+
 ## One of Instructime's Prompt
 
 ```

--- a/TStokenizer/loss.py
+++ b/TStokenizer/loss.py
@@ -20,7 +20,7 @@ class MSE:
         self.latent_loss_weight = latent_loss_weight
         self.mse = nn.MSELoss()
 
-    def compute(self, batch):
+    def compute(self, batch, mask=None):
         """
         功能: 计算模型的总损失
         输入:
@@ -35,11 +35,12 @@ class MSE:
         """
         seqs = batch
         # 前向传播，得到重构结果、latent损失和token索引
-        out, latent_loss, _ = self.model(seqs)
-        # 计算重构损失：原始输入与重构输出的MSE
-        recon_loss = self.mse(out, seqs)
-        # 计算latent损失均值
+        out, latent_loss, _ = self.model(seqs, mask=mask)
+
+        if mask is not None:
+            recon_loss = ((out - seqs) ** 2 * mask).sum() / mask.sum()
+        else:
+            recon_loss = self.mse(out, seqs)
         latent_loss = latent_loss.mean()
-        # 计算总损失：重构损失 + 加权latent损失
         loss = recon_loss + self.latent_loss_weight * latent_loss
         return loss

--- a/TStokenizer/main.py
+++ b/TStokenizer/main.py
@@ -65,9 +65,9 @@ def main():
     train_loader = Data.DataLoader(train_dataset, batch_size=args.train_batch_size, shuffle=True)
     args.data_shape = train_dataset.shape()
     
-    # 加载测试数据集
-    test_dataset = Dataset(device=args.device, mode='test', args=args)
-    test_loader = Data.DataLoader(test_dataset, batch_size=args.test_batch_size)
+    # 加载验证数据集
+    val_dataset = Dataset(device=args.device, mode='test', args=args)
+    val_loader = Data.DataLoader(val_dataset, batch_size=args.test_batch_size)
     print(args.data_shape)
     print('dataset initial ends')
 
@@ -82,7 +82,7 @@ def main():
     print('model initial ends')
 
     # 创建训练器对象，管理训练和评估流程
-    trainer = Trainer(args, model, train_loader, test_loader, verbose=True)
+    trainer = Trainer(args, model, train_loader, val_loader, verbose=True)
     print('trainer initial ends')
 
     # 开始训练过程

--- a/icu_codebook.py
+++ b/icu_codebook.py
@@ -1,0 +1,159 @@
+import os
+import os
+import pickle
+from typing import List, Tuple
+
+import numpy as np
+import torch
+from torch import nn
+from torch.utils.data import Dataset, DataLoader
+import torch.nn.functional as F
+
+from TStokenizer.model import TStokenizer
+
+
+class ICUTimeSeriesDataset(Dataset):
+    """Dataset returning padded sequence, mask and valid length."""
+
+    def __init__(self, root: str, split: str, max_len: int = 48):
+        self.data: List[np.ndarray] = []
+        self.masks: List[np.ndarray] = []
+        self.lengths: List[int] = []
+        self.max_len = max_len
+
+        for task in ["ihm", "pheno"]:
+            p = os.path.join(root, task, f"{split}_p2x_data.pkl")
+            if not os.path.isfile(p):
+                continue
+            with open(p, "rb") as f:
+                samples = pickle.load(f)
+            for sample in samples:
+                seq = np.asarray(sample["reg_ts"], dtype=np.float32)
+                valid_len = min(len(seq), self.max_len)
+                mask = np.zeros(self.max_len, dtype=np.float32)
+                mask[:valid_len] = 1.0
+                if len(seq) < self.max_len:
+                    pad = np.zeros((self.max_len - len(seq), seq.shape[1]), dtype=np.float32)
+                    seq = np.concatenate([seq, pad], axis=0)
+                else:
+                    seq = seq[:self.max_len]
+
+                self.data.append(seq)
+                self.masks.append(mask[:, None])
+                self.lengths.append(valid_len)
+
+    def __len__(self) -> int:
+        return len(self.data)
+
+    def __getitem__(self, idx: int) -> Tuple[torch.Tensor, torch.Tensor, int]:
+        return (
+            torch.from_numpy(self.data[idx]),
+            torch.from_numpy(self.masks[idx]),
+            self.lengths[idx],
+        )
+
+
+def train_icu_codebook(
+    data_root: str,
+    save_path: str = "vq.ckpt",
+    *,
+    epochs: int = 30,
+    lr: float = 1e-3,
+    batch_size: int = 64,
+    device: str = "cuda",
+) -> None:
+    """Train VQ-VAE codebook on IHM+PHE datasets."""
+
+    train_set = ICUTimeSeriesDataset(data_root, "train")
+    val_set = ICUTimeSeriesDataset(data_root, "val")
+    train_loader = DataLoader(train_set, batch_size=batch_size, shuffle=True)
+    val_loader = DataLoader(val_set, batch_size=batch_size)
+
+    model = TStokenizer(
+        data_shape=(48, 34), hidden_dim=64, n_embed=256, block_num=4, wave_length=4
+    ).to(device)
+    optim = torch.optim.Adam(model.parameters(), lr=lr)
+
+    for _ in range(epochs):
+        model.train()
+        for seqs, mask, _ in train_loader:
+            seqs = seqs.to(device)
+            mask = mask.to(device)
+            recon, diff, _ = model(seqs, mask=mask)
+            recon_loss = ((recon - seqs) ** 2 * mask).sum() / mask.sum()
+            loss = recon_loss + diff
+            optim.zero_grad()
+            loss.backward()
+            optim.step()
+
+        # simple val loss print
+        model.eval()
+        with torch.no_grad():
+            losses = []
+            for seqs, mask, _ in val_loader:
+                seqs = seqs.to(device)
+                mask = mask.to(device)
+                recon, diff, _ = model(seqs, mask=mask)
+                recon_loss = ((recon - seqs) ** 2 * mask).sum() / mask.sum()
+                losses.append((recon_loss + diff).item())
+        print(f"val_loss: {np.mean(losses):.4f}")
+
+    torch.save(model.state_dict(), save_path)
+
+
+class ICUCodebook(nn.Module):
+    """Utility wrapper providing ``encode`` for trained codebook."""
+
+    def __init__(self, ckpt_path: str, device: str = "cpu"):
+        super().__init__()
+        self.device = device
+        self.model = TStokenizer(data_shape=(48, 34), hidden_dim=64, n_embed=256,
+                                 block_num=4, wave_length=4)
+        self.model.load_state_dict(torch.load(ckpt_path, map_location=device))
+        self.model.to(device)
+        self.model.eval()
+
+    @torch.no_grad()
+    def encode(self, ts: np.ndarray, valid_len: int | None = None) -> np.ndarray:
+        """Convert ``(T,34)`` array into token indices.
+
+        Parameters
+        ----------
+        ts : np.ndarray
+            Time series with shape ``(T, 34)``.
+        valid_len : int, optional
+            Actual sequence length. If ``None``, use ``ts.shape[0]``.
+        """
+        arr = np.asarray(ts, dtype=np.float32)
+        valid_len = arr.shape[0] if valid_len is None else valid_len
+        arr = arr[:valid_len]
+        if arr.shape[0] < 48:
+            pad = np.zeros((48 - arr.shape[0], arr.shape[1]), dtype=np.float32)
+            arr = np.concatenate([arr, pad], axis=0)
+        tensor = torch.from_numpy(arr).unsqueeze(0).to(self.device)
+        mask = torch.zeros(1, 48, 1, device=self.device)
+        mask[0, :valid_len] = 1
+        _, _, ids = self.model(tensor, mask=mask)
+        patch_len = self.model.wave_patch[0]
+        max_tokens = ids.shape[1]
+        valid_tokens = (valid_len + patch_len - 1) // patch_len
+        return ids[:, :valid_tokens].squeeze(0).cpu().numpy()
+
+
+__all__ = ["ICUTimeSeriesDataset", "train_icu_codebook", "ICUCodebook"]
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Train ICU VQ codebook")
+    parser.add_argument("--data_root", type=str, required=True,
+                        help="Path containing ihm/ and pheno/ folders")
+    parser.add_argument("--save_path", type=str, default="vq.ckpt")
+    parser.add_argument("--epochs", type=int, default=30)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--device", type=str, default="cuda")
+    args = parser.parse_args()
+
+    train_icu_codebook(args.data_root, save_path=args.save_path,
+                       epochs=args.epochs, lr=args.lr, device=args.device)
+


### PR DESCRIPTION
## Summary
- support variable-length records in `ICUTimeSeriesDataset`
- train ICU codebook with padding masks
- ignore padding in reconstruction and VQ losses
- allow `ICUCodebook.encode` to skip padded steps
- rename Trainer loaders to `val_loader`

## Testing
- `python -m py_compile icu_codebook.py TStokenizer/process.py TStokenizer/main.py TStokenizer/main_eval.py TStokenizer/loss.py`